### PR TITLE
fix(full-bundle): add missing tsconfig.json

### DIFF
--- a/packages/openbridge-webcomponents/script/prepare-full-bundle.ts
+++ b/packages/openbridge-webcomponents/script/prepare-full-bundle.ts
@@ -41,10 +41,12 @@ for (const dirName of ['dist', 'bundle', 'src', 'docs']) {
   );
 }
 
-fs.copyFileSync(
-  path.join(packageRoot, 'custom-elements.json'),
-  path.join(fullBundlePackageRoot, 'custom-elements.json')
-);
+for (const file of ['custom-elements.json', 'tsconfig.json']) {
+  fs.copyFileSync(
+    path.join(packageRoot, file),
+    path.join(fullBundlePackageRoot, file)
+  );
+}
 
 fs.writeFileSync(
   path.join(fullBundlePackageRoot, 'package.json'),

--- a/packages/openbridge-webcomponents/script/prepare-full-bundle.ts
+++ b/packages/openbridge-webcomponents/script/prepare-full-bundle.ts
@@ -9,7 +9,7 @@ const sourcePackagePath = path.join(packageRoot, 'package.json');
 const fullBundlePackageRoot = path.join(packageRoot, '.full-bundle-publish');
 const sourcePackage = JSON.parse(fs.readFileSync(sourcePackagePath, 'utf-8'));
 const releaseVersion = process.argv[2] ?? sourcePackage.version;
-const {scripts: _sourceScripts, ...sourcePackageWithoutScripts} = sourcePackage;
+const {...sourcePackageWithoutScripts} = sourcePackage;
 
 const fullBundlePackage = {
   ...sourcePackageWithoutScripts,
@@ -22,6 +22,7 @@ const fullBundlePackage = {
     'bundle/openbridge-webcomponents.bundle.js',
     'bundle/openbridge-webcomponents.bundle.js.map',
     'custom-elements.json',
+    'tsconfig.json',
     'src',
     'docs',
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Full-bundle package generation now preserves package.json "scripts" when building the publish package.
  * tsconfig is now included in the generated package files, and both metadata and config artifacts are copied into the publish directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ocean-Industries-Concept-Lab/openbridge-webcomponents/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->