### PR TITLE
Bug/runaway resizing tanks

### DIFF
--- a/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.stories.ts
+++ b/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.stories.ts
@@ -1434,3 +1434,129 @@ export const BugHorizontalRinging: Story = {
       `
     ),
 };
+
+// Two independent ways the chart ends up smaller than the cell it was given:
+// a `zoom`ed ancestor (any tank size), and a chart cell wider than 2:1.
+// `zoom: 0.8` is what the Perspective workstation stylesheet sets globally.
+const CHART_FILL_CASES = [
+  {width: 256, height: 376, zoom: 1},
+  {width: 200, height: 352, zoom: 0.8},
+  {width: 200, height: 352, zoom: 0.5},
+  {width: 1600, height: 640, zoom: 1},
+  {width: 1600, height: 640, zoom: 0.8},
+];
+
+const chartFillProbes = new Set<number>();
+
+/** Live cell-vs-canvas readout, so the gap is a number rather than an impression. */
+const measureChartFill = (root?: Element): void => {
+  if (!(root instanceof HTMLElement)) {
+    chartFillProbes.forEach((id) => clearInterval(id));
+    chartFillProbes.clear();
+    return;
+  }
+  const paint = () => {
+    root.querySelectorAll('[data-fill-box]').forEach((node) => {
+      const shadow = node.querySelector('obc-automation-tank')?.shadowRoot;
+      const cell = shadow?.querySelector('.bar-container');
+      const canvas = shadow
+        ?.querySelector('obc-gauge-trend')
+        ?.shadowRoot?.querySelector('canvas');
+      const out = node.previousElementSibling as HTMLElement | null;
+      if (!cell || !canvas || !out) return;
+      // Both rects are in the same (zoomed) space, so the ratio is honest.
+      const b = cell.getBoundingClientRect();
+      const c = canvas.getBoundingClientRect();
+      const fill = (c.width * c.height) / (b.width * b.height);
+      out.textContent =
+        `zoom ${node.getAttribute('data-zoom')}` +
+        `   cell ${Math.round(b.width)}×${Math.round(b.height)} ` +
+        `(${(b.width / b.height).toFixed(2)}:1)` +
+        `   canvas ${Math.round(c.width)}×${Math.round(c.height)}` +
+        `   unused ${Math.round(b.width - c.width)}×${Math.round(b.height - c.height)}px` +
+        `   fills ${(fill * 100).toFixed(0)}% of the cell` +
+        (fill > 0.99 ? '   ✓' : '   ←');
+    });
+  };
+  paint();
+  chartFillProbes.add(window.setInterval(paint, 500));
+};
+
+/**
+ * **Bug — the chart canvas does not fill the chart cell.**
+ *
+ * Every box below has a definite pixel size and the tank fills its slot
+ * correctly; the chart inside the tank frame does not. Two independent causes,
+ * either of which is enough on its own:
+ *
+ * 1. **A `zoom`ed ancestor.** The canvas comes out at `zoom²` of the cell —
+ *    64% of the width and height at `zoom: 0.8`, i.e. 41% of the area — at any
+ *    tank size or aspect. Chart.js measures the container with
+ *    `getBoundingClientRect()`, which is already zoom-scaled, then writes that
+ *    number back as a CSS-pixel inline `style` on the canvas, so the browser
+ *    scales it a second time. At `zoom > 1` the canvas overflows instead.
+ * 2. **A chart cell wider than 2:1.** The canvas stops at `cell height × 2`.
+ *
+ * The rows are the two shapes seen in the field: a small portrait tank in a
+ * dashboard row under the workstation's global `zoom: 0.8`, and a single wide
+ * tank on a full-width page. The last row has both.
+ *
+ * The numbers above each box are measured live from the DOM. `bar` mode has no
+ * canvas and is unaffected; `graph` behaves the same as `graph-and-bar`.
+ *
+ * Both causes are isolated without any tank in
+ * `Instruments/Gauge Trend → BUG: CSS Zoom Shrinks The Chart Canvas` and
+ * `→ BUG: Canvas Never Exceeds 2 × Its Height`.
+ */
+export const BugChartCanvasDoesNotFillCell: Story = {
+  name: 'BUG: Chart Canvas Does Not Fill The Chart Cell',
+  args: {
+    type: TankType.generic,
+    chartMode: TankChartMode.graphAndBar,
+    positioning: TankPositioning.button,
+    showTrendSymbol: false,
+    percentFractionDigits: 1,
+  },
+  decorators: [],
+  parameters: {controls: {disable: true}},
+  render: (args) => html`
+    <div
+      style="position: static; display: flex; flex-direction: column; gap: 16px; padding: 8px; overflow: auto;"
+      ${ref(measureChartFill)}
+    >
+      ${CHART_FILL_CASES.map(
+        (size) => html`
+          <div>
+            <code
+              style="display: block; margin-bottom: 4px; font: 12px/1.6 monospace; color: var(--element-neutral-color);"
+              >measuring…</code
+            >
+            <div
+              data-fill-box
+              data-zoom=${size.zoom}
+              style="
+                zoom: ${size.zoom};
+                width: ${size.width}px;
+                height: ${size.height}px;
+                box-sizing: border-box;
+                outline: 1px dashed var(--border-divider-color);
+              "
+            >
+              <obc-automation-tank
+                .value=${args.value}
+                .max=${args.max}
+                .tag=${`${size.width}×${size.height} @ ${size.zoom}`}
+                .type=${args.type}
+                .positioning=${args.positioning}
+                .chartMode=${args.chartMode}
+                .chartData=${SAMPLE_DATA}
+                .showTrendSymbol=${args.showTrendSymbol}
+                .percentFractionDigits=${args.percentFractionDigits}
+              ></obc-automation-tank>
+            </div>
+          </div>
+        `
+      )}
+    </div>
+  `,
+};

--- a/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.stories.ts
+++ b/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.stories.ts
@@ -11,6 +11,7 @@ import './automation-tank.js';
 import '../../navigation-instruments/readout-list/readout-list.js';
 import '../../navigation-instruments/readout-list-item/readout-list-item.js';
 import {html, nothing} from 'lit';
+import {ref} from 'lit/directives/ref.js';
 import {crossDecorator} from '../../storybook-util.js';
 import {AdviceType} from '../../navigation-instruments/watch/advice.js';
 import type {LinearAdvice} from '../../building-blocks/instrument-linear/advice.js';
@@ -847,4 +848,589 @@ export const Responsive: Story = {
       </div>
     `;
   },
+};
+
+// ---------------------------------------------------------------------------
+// Ignition Perspective flex-repeater reproduction
+// ---------------------------------------------------------------------------
+// Mirrors the DOM an `ia.display.flex-repeater` produces for the Vessel /
+// Tank Status page: a wrapping flex line of instances whose cross-axis size is
+// content-derived (`elementPosition.basis: "auto"`, `useDefaultViewHeight` and
+// `useDefaultViewWidth` both `false`), each instance holding a column
+// `ia.container.flex` with the tank at `align: center, grow: 1`. The
+// obc-perspective wrapper defaults `positioning` to `button`, so the tank host
+// is `width/height: 100%` with the min-size floors dropped.
+
+const REPEATER_TANKS = [
+  {tag: 'FO TOT', value: 61.4, max: 76.21, points: 8},
+  {tag: 'FO SERV SB', value: 0.82, max: 1.06, points: 11},
+  {tag: 'FO SERV PS', value: 0.41, max: 1.06, points: 14},
+  {tag: 'OVERFLOW', value: 2.3, max: 17.4, points: 17},
+  {tag: 'AFT SB FO', value: 14.9, max: 17.4, points: 20},
+  {tag: 'FWD SB FO', value: 8.7, max: 20.26, points: 23},
+  {tag: 'FWD PS FO', value: 17.2, max: 19.03, points: 12},
+  {tag: 'UREA', value: 3.9, max: 5.5, points: 16},
+];
+
+// Series lengths deliberately differ per tank, matching real repeater data.
+const repeaterSeries = (points: number, seed: number) =>
+  Array.from({length: points}, (_, i) => ({
+    label: String(i).padStart(2, '0'),
+    value: 2_000 + (((i + seed) * 1_900) % 7_000),
+  }));
+
+/**
+ * Instrumentation: records the distinct rendered sizes of every tank host. A
+ * settled layout converges on one size per tank and stops calling back; a
+ * non-convergent one keeps accumulating sizes. Also reports whether the chart
+ * cell actually has a renderer in it, and keeps a rolling trace of the first
+ * tank so a few-pixel ringing is legible.
+ */
+const probeResets = new WeakMap<Element, () => void>();
+const probeStops = new WeakMap<Element, () => void>();
+
+const attachOscillationProbe = (container?: Element): void => {
+  if (!container) return;
+  probeStops.get(container)?.();
+
+  // Deferred one frame: the ref callback commits before the sibling template
+  // parts that create the readout panel and the tanks.
+  const startFrame = requestAnimationFrame(() => {
+    const panel = container.querySelector('.probe-readout');
+    const tanks = Array.from(container.querySelectorAll('obc-automation-tank'));
+    if (!panel || tanks.length === 0) return;
+
+    let sizes = tanks.map(() => new Set<string>());
+    let callbacks = tanks.map(() => 0);
+    let trace: string[] = [];
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const index = tanks.findIndex((tank) => tank === entry.target);
+        if (index < 0) continue;
+        const size = `${Math.round(entry.contentRect.width)}×${Math.round(entry.contentRect.height)}`;
+        sizes[index].add(size);
+        callbacks[index] += 1;
+        if (index === 0) trace = [...trace, size].slice(-14);
+      }
+    });
+    tanks.forEach((tank) => observer.observe(tank));
+
+    const reportTimer = window.setInterval(() => {
+      const lines = tanks.map((tank, index) => {
+        const label = (tank as ObcAutomationTank).tag || `tank ${index}`;
+        const cell = tank.shadowRoot?.querySelector('.bar-container');
+        const chart = cell && cell.children.length > 0 ? 'yes' : 'NO ';
+        const now = [...sizes[index]].pop() ?? '—';
+        return `${label.padEnd(9)} ${String(sizes[index].size).padStart(4)} sizes ${String(callbacks[index]).padStart(5)} cb  chart:${chart}  now ${now}`;
+      });
+      panel.textContent = `${lines.join('\n')}\n\ntrace (${(tanks[0] as ObcAutomationTank).tag}): ${trace.join('  ')}`;
+    }, 250);
+
+    probeResets.set(container, () => {
+      sizes = tanks.map(() => new Set<string>());
+      callbacks = tanks.map(() => 0);
+      trace = [];
+    });
+
+    // Each layout change makes the tanks ring for about a second and land on a
+    // different width. In the gateway the loop is self-sustaining; in isolation
+    // it damps out, so this nudges the row by a scrollbar's width to keep
+    // supplying the relayouts a live page gets for free. Driving `value`,
+    // digit count, slotted text or new chartData identities was tried first and
+    // none of them moves the layout at all.
+    let nudgeTimer = 0;
+    const row = container.querySelector('[data-row]') as HTMLElement | null;
+    if (container.hasAttribute('data-tick') && row) {
+      let wide = false;
+      nudgeTimer = window.setInterval(() => {
+        wide = !wide;
+        row.style.width = wide ? 'calc(100% - 14px)' : '100%';
+      }, 1_200);
+    }
+
+    probeStops.set(container, () => {
+      observer.disconnect();
+      window.clearInterval(reportTimer);
+      if (nudgeTimer) window.clearInterval(nudgeTimer);
+    });
+  });
+
+  probeStops.set(container, () => cancelAnimationFrame(startFrame));
+};
+
+// Row geometry. `DEFINITE_*` pins both axes (the layout that behaves); the
+// `FREE_*` variants hand an axis back to content, which is what
+// `elementPosition.basis: "auto"` / `useDefaultViewHeight: false` and the tank's
+// `align: center` do in Perspective.
+const DEFINITE_ROW = 'display: flex; height: 420px;';
+const FREE_HEIGHT_ROW = 'display: flex;';
+const DEFINITE_INSTANCE =
+  'flex: 0 0 auto; width: 320px; padding: 5px; box-sizing: border-box;';
+
+const rootOf = (el: EventTarget | null) =>
+  (el as HTMLElement | null)?.closest(
+    '[data-probe-root]'
+  ) as HTMLElement | null;
+
+// `_cellWidth` / `_cellHeight` survive a detach, so the cold-start deadlock can
+// only be shown on genuinely fresh elements. Every tank must come out before any
+// goes back in — otherwise the remaining siblings hold the row open and the
+// replacements measure a non-zero cell.
+const remountTanks = (root: HTMLElement): void => {
+  const specs = [...root.querySelectorAll('obc-automation-tank')].map(
+    (node) => {
+      const old = node as ObcAutomationTank;
+      return {
+        parent: old.parentElement,
+        style: old.getAttribute('style') ?? '',
+        props: {
+          value: old.value,
+          max: old.max,
+          tag: old.tag,
+          type: old.type,
+          positioning: old.positioning,
+          chartMode: old.chartMode,
+          chartData: old.chartData,
+          showTrendSymbol: old.showTrendSymbol,
+          percentFractionDigits: old.percentFractionDigits,
+        },
+      };
+    }
+  );
+  specs.forEach((spec) =>
+    spec.parent?.querySelector('obc-automation-tank')?.remove()
+  );
+  specs.forEach((spec) => {
+    const fresh = document.createElement(
+      'obc-automation-tank'
+    ) as ObcAutomationTank;
+    Object.assign(fresh, spec.props);
+    fresh.setAttribute('style', spec.style);
+    spec.parent?.appendChild(fresh);
+  });
+};
+
+const applyLayout = (
+  target: EventTarget | null,
+  rowStyle: string,
+  instanceStyle: string,
+  remount = false
+): void => {
+  const root = rootOf(target);
+  const repeater = root?.querySelector('[data-repeater]') as HTMLElement | null;
+  if (!root || !repeater) return;
+  repeater.setAttribute('style', rowStyle);
+  [...repeater.children].forEach((child) =>
+    child.setAttribute('style', instanceStyle)
+  );
+  if (remount) {
+    remountTanks(root);
+    attachOscillationProbe(root);
+    return;
+  }
+  probeResets.get(root)?.();
+};
+
+const buttonStyle = 'padding: 6px 10px;';
+
+/*
+ * SHARED ROOT CAUSE (all three bug stories below)
+ * Root cause (all three stories): the tank measures .bar-container with a
+ * ResizeObserver into _cellWidth / _cellHeight (automation-tank.ts ~L420) and
+ * passes them to the chart as its reference size. The chart converts that back
+ * into intrinsic pixels, which changes the very box that was measured.
+ *
+ * An axis left to content therefore never resolves to a stable value. Pinning the
+ * axis breaks the loop, which is why giving the row a definite size fixes all
+ * three.
+ */
+
+const renderScenario = (
+  args: StoryArgs,
+  rowStyle: string,
+  instanceStyle: string,
+  controls: unknown,
+  rowWidth = 1_800
+) => html`
+  <!-- Inline position beats the shared crossDecorator's
+       \`.wrapper > * {position:absolute; top:50%; left:50%}\`, which would push
+       these full-width layouts into the bottom-right quadrant. -->
+  <div
+    data-probe-root
+    style="position: static; padding: 8px;"
+    ${ref(attachOscillationProbe)}
+  >
+    <div
+      style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 8px;"
+    >
+      ${controls}
+    </div>
+    <pre
+      class="probe-readout"
+      style="
+        margin: 0 0 8px;
+        padding: 8px;
+        font: 12px/1.5 monospace;
+        white-space: pre;
+        color: var(--element-neutral-color);
+        border: 1px solid var(--border-divider-color);
+      "
+    >
+sampling…</pre
+    >
+    <!-- Scrolls rather than clips, so a runaway never grows the page itself. -->
+    <div
+      style="height: 460px; overflow: auto; border: 1px dashed var(--border-divider-color);"
+    >
+      <div data-row style="width: ${rowWidth}px;">
+        <div data-repeater style=${rowStyle}>
+          ${REPEATER_TANKS.map(
+            (tank, index) => html`
+              <div style=${instanceStyle}>
+                <div
+                  style="display: flex; flex-direction: column; height: 100%; padding: 8px; box-sizing: border-box; border: 1px solid var(--border-divider-color);"
+                >
+                  <obc-automation-tank
+                    style="align-self: center; flex-grow: 1;"
+                    .value=${tank.value}
+                    .max=${tank.max}
+                    .tag=${tank.tag}
+                    .type=${args.type}
+                    .positioning=${TankPositioning.button}
+                    .chartMode=${args.chartMode}
+                    .chartData=${repeaterSeries(tank.points, index)}
+                    .showTrendSymbol=${false}
+                    .percentFractionDigits=${1}
+                  ></obc-automation-tank>
+                </div>
+              </div>
+            `
+          )}
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+
+// Byte-for-byte replica of the DOM and inline styles Perspective emits for an
+// `ia.display.flex-repeater`, read off a running Ignition gateway. The details
+// that matter and are easy to get wrong:
+//   - the instance uses min-height/max-height, NOT height, so its `height`
+//     property is `auto` and the tank's `height: 100%` never resolves
+//   - a component wrapper div sits between the instance and the tank, carrying
+//     `align-self: center; flex: 1 1 auto` from the tank's `position`
+//   - `.responsive-container > *` sets min-width/min-height to 0
+const PERSPECTIVE_REPEATER =
+  'display: flex; overflow: auto; flex-flow: row; place-content: stretch flex-start; align-items: stretch; flex: 0 0 360px;';
+const PERSPECTIVE_INSTANCE =
+  'display: flex; overflow: auto; flex-flow: column; place-content: stretch flex-start; align-items: stretch; min-height: 340px; max-height: 340px; flex: 1 1 auto; margin: 4px; min-width: 0;';
+const PERSPECTIVE_INSTANCE_PINNED =
+  'display: flex; overflow: auto; flex-flow: column; place-content: stretch flex-start; align-items: stretch; min-height: 340px; max-height: 340px; flex: 0 0 160px; width: 160px; margin: 4px; min-width: 0;';
+// `.obc-automation-tank-component` — `align-self: center; flex: 1 1 auto` comes
+// from the tank's `position: {align: "center", grow: 1}`.
+const PERSPECTIVE_WRAPPER =
+  'align-self: center; flex: 1 1 auto; min-width: 0; min-height: 0;';
+
+const renderPerspectiveReplica = (args: StoryArgs, controls: unknown) => html`
+  <div
+    data-probe-root
+    data-tick
+    style="position: static; padding: 8px;"
+    ${ref(attachOscillationProbe)}
+  >
+    <div
+      style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 8px;"
+    >
+      ${controls}
+    </div>
+    <pre
+      class="probe-readout"
+      style="
+        margin: 0 0 8px;
+        padding: 8px;
+        font: 12px/1.5 monospace;
+        white-space: pre;
+        color: var(--element-neutral-color);
+        border: 1px solid var(--border-divider-color);
+      "
+    >
+sampling…</pre
+    >
+    <div data-row style="width: 100%;">
+      <div data-repeater style=${PERSPECTIVE_REPEATER}>
+        ${REPEATER_TANKS.map(
+          (tank, index) => html`
+            <div style=${PERSPECTIVE_INSTANCE}>
+              <div style=${PERSPECTIVE_WRAPPER}>
+                <obc-automation-tank
+                  .value=${tank.value}
+                  .max=${tank.max}
+                  .tag=${tank.tag}
+                  .type=${args.type}
+                  .positioning=${TankPositioning.button}
+                  .chartMode=${args.chartMode}
+                  .chartData=${repeaterSeries(tank.points, index)}
+                  .showTrendSymbol=${false}
+                  .percentFractionDigits=${1}
+                >
+                  <span slot="current-value" data-current-value
+                    >${tank.value}</span
+                  >
+                  <span slot="max-value">${tank.max}</span>
+                </obc-automation-tank>
+              </div>
+            </div>
+          `
+        )}
+      </div>
+    </div>
+  </div>
+`;
+
+const scenarioArgs = {
+  type: TankType.atmospheric,
+  positioning: TankPositioning.button,
+  showTrendSymbol: false,
+  percentFractionDigits: 1,
+} satisfies Partial<StoryArgs>;
+
+/**
+ * **Bug 1 — the chart never initialises.**
+ *
+ * The row is mounted with no definite height, so `.bar-container` measures 0 on
+ * the first pass, `_cellHeight` stays 0 and the `hasSize` guard renders an empty
+ * chart cell. Because the cell is then permanently empty it never gains height,
+ * so it never recovers.
+ *
+ * On load every tank reports `chart:NO` and sits at its min-content size
+ * (≈258×143 instead of 258×392). Press *Give the row a definite height* and the
+ * charts appear immediately — the component is fine, it just cannot bootstrap
+ * itself from a content-sized container.
+ */
+export const BugChartCellNeverInitialises: Story = {
+  args: {...scenarioArgs, chartMode: TankChartMode.graphAndBar},
+  decorators: [],
+  render: (args) =>
+    renderScenario(
+      args,
+      FREE_HEIGHT_ROW,
+      DEFINITE_INSTANCE,
+      html`
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(e.currentTarget, DEFINITE_ROW, DEFINITE_INSTANCE)}
+        >
+          Give the row a definite height (fixes it)
+        </button>
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(
+              e.currentTarget,
+              FREE_HEIGHT_ROW,
+              DEFINITE_INSTANCE,
+              true
+            )}
+        >
+          Remount into a content-sized row (breaks it again)
+        </button>
+      `
+    ),
+};
+
+/**
+ * **Bug 2 — unbounded vertical growth**, `chartMode: bar`.
+ *
+ * Starts with both axes definite and settled at 292×392. Press *Release the row
+ * height* and the tank grows forever: measured 252 distinct sizes and 252 resize
+ * callbacks in 4s, climbing 292×392 → 292×1857 and still going. Watch the
+ * `now` column and the trace in the readout.
+ *
+ * The row is inside a scrollable dashed box so the page itself never grows — on
+ * a real page this is what silently adds scrollbars.
+ *
+ * `obc-bar-vertical` writes inline `width: auto; height: 100%` onto its own host
+ * in `_applyFixedAspectRatioStyles()`, so its height comes from the measurement
+ * the tank took of the cell that contains it.
+ */
+export const BugUnboundedVerticalGrowth: Story = {
+  args: {...scenarioArgs, chartMode: TankChartMode.bar},
+  decorators: [],
+  render: (args) =>
+    renderScenario(
+      args,
+      DEFINITE_ROW,
+      DEFINITE_INSTANCE,
+      html`
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(e.currentTarget, FREE_HEIGHT_ROW, DEFINITE_INSTANCE)}
+        >
+          Release the row height (reproduce)
+        </button>
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(e.currentTarget, DEFINITE_ROW, DEFINITE_INSTANCE)}
+        >
+          Reset
+        </button>
+      `
+    ),
+};
+
+/**
+ * **Bug 3 — damped horizontal ringing**, `chartMode: graph` / `graph-and-bar`.
+ *
+ * Press *Release both axes*, then *Toggle row width ±15px*.
+ *
+ * With both axes content-derived and the row over-subscribed enough for
+ * flex-shrink to be active, the width overshoots and rings before settling —
+ * 274 → 281 → 272 → 273 → 273 → 272 over roughly a second. It is a damped
+ * oscillator, not a free-running loop, so a single release rings once and stops.
+ *
+ * The toggle makes that falsifiable: it drives the row between exactly **two**
+ * widths, so a well-behaved component would visit exactly two sizes. Instead the
+ * `sizes` counter climbs past 35 and the trace shows intermediate values
+ * (296 → 297 → 297 → 298 → 296) that correspond to no input.
+ *
+ * Caveat: this is a *damped* oscillator with a 3–7px amplitude that settles
+ * within a few seconds. It reproduces the measurable non-convergence but not the
+ * continuous bouncing seen in the field, whose source of repeated perturbation
+ * has not been identified.
+ *
+ * Both axes must be free — pinning either one alone removes it, which is why
+ * only the combination of `align: center` → stretch *and* a definite
+ * `elementPosition.basis` fixed the Perspective view.
+ *
+ * It also only rings inside a row-width band. With six tanks that is roughly
+ * 1200–1950px; outside it the layout settles immediately. Use the slider to
+ * sweep it.
+ */
+/*
+ * BUG 3 — NOTES FOR THE MAINTAINER
+ * (see SHARED_ROOT_CAUSE above)
+ *
+ * obc-gauge-trend hardcodes fixedAspectRatioScaling = true (gauge-trend.ts:155).
+ * chart-line-base updateComputedDimensions() (L1795) derives a pixel height from
+ * the measured width and publishes it as an inline --chart-height (L2189), while
+ * chart-common.css gives the chart host a width but NO height. So the chart height
+ * is intrinsic content computed from its own measured width, and the tank content
+ * width depends on that height. The width has no fixed point.
+ *
+ * This story is a replica of the DOM and inline styles Perspective emits for an
+ * ia.display.flex-repeater, read off a running Ignition gateway. The details that
+ * make or break the reproduction:
+ *
+ *   1. The instance uses min-height/max-height: 340px, NOT height. The box looks
+ *      340px tall but its height PROPERTY is auto, so the tank height: 100% never
+ *      resolves and falls back to content. Using height: 340px instead makes the
+ *      whole thing stable and hides the bug.
+ *   2. A component wrapper div sits between instance and tank carrying
+ *      align-self: center + flex: 1 1 auto, from the tank position
+ *      {align: "center", grow: 1}. align-self: center is what makes the width
+ *      shrink-to-fit, i.e. content-derived.
+ *   3. .responsive-container > * sets min-width/min-height to 0, so nothing floors
+ *      the shrink.
+ *   4. instance flex: 1 1 auto and repeater align-items: stretch.
+ *   5. The values are the vessel ones (61.4 / 76.21 ...). With large values the
+ *      readout text pins the width and the bug disappears.
+ *
+ * In Perspective terms this is useDefaultViewHeight: true + useDefaultViewWidth:
+ * false: height pinned so every chart initialises, width content-derived and free.
+ *
+ * A ticker rewrites every value once a second, standing in for the tag binding.
+ *
+ * Measured in Ignition, project data/projects/tank-resize-repro on the container
+ * gateway (port 8090): 8 tanks on one line, every chart rendered, 5-8 distinct
+ * sizes and 10 resize callbacks per tank in 12s, container fixed at 1400x360 and
+ * the page never scrolling.
+ *
+ * This is NOT a consumer CSS mistake. The same markup with chartMode bar is
+ * stable, and giving the tank a definite size does not fix the component, it just
+ * stops asking it a question it cannot answer.
+ *
+ * CAPTURED FROM THE RUNNING GATEWAY. A MutationObserver + ResizeObserver on the
+ * Ignition page recorded this, with no input of any kind - the loop is
+ * self-sustaining and needs no tag updates at all:
+ *
+ *   13   ATTR   GAUGE-TREND.width = 288
+ *   51   ATTR   GAUGE-TREND.style --chart-height: 231px
+ *   91   RESIZE TANK 149x340 / CELL 121x226
+ *   97   ATTR   GAUGE-TREND.width = 121
+ *   143  ATTR   --chart-height: 219px
+ *   205  ATTR   --chart-height: 217px
+ *   245  ATTR   --chart-height: 232px
+ *   363  ATTR   GAUGE-TREND.width = 133
+ *   449  RESIZE TANK 164x340
+ *   455  ATTR   GAUGE-TREND.width = 136
+ *   ...  TANK width goes 149 -> 164 -> 162 -> 174 -> 160 -> ... indefinitely
+ *
+ * That is the closed loop in one trace: --chart-height (px) -> canvas intrinsic
+ * width -> tank max-content width -> instance width -> cell width ->
+ * gauge-trend.width -> --chart-height.
+ *
+ * Two conditions are easy to get wrong when reproducing:
+ *   - type must be "generic". The atmospheric caps widen the tank's min-content
+ *     enough that the text pins the width and the loop never engages.
+ *   - the values must be small (61.4 / 76.21). With large values the readout text
+ *     pins min-content and the bug disappears.
+ *
+ * KNOWN GAP: this isolated story rings on load (9-11 distinct sizes, 12 resize
+ * callbacks per tank, tank width 161 which matches the gateway's ~160) and then
+ * settles, whereas the gateway never settles. Driving value, digit count, slotted
+ * text and new chartData identities were all tried and none sustains it here. The
+ * Ignition project remains the authoritative reproduction of the sustained
+ * symptom.
+ *
+ * How to read it: compare the sizes and cb counters against the pinned state.
+ * Press "Pin the width" and they drop to 1 size / 1 callback immediately.
+ */
+
+export const BugHorizontalRinging: Story = {
+  // `generic` matches the Tank Status page; the atmospheric caps widen
+  // min-content enough to hide the loop.
+  args: {
+    ...scenarioArgs,
+    type: TankType.generic,
+    chartMode: TankChartMode.graphAndBar,
+  },
+  decorators: [],
+  render: (args) =>
+    renderPerspectiveReplica(
+      args,
+      html`
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(
+              e.currentTarget,
+              PERSPECTIVE_REPEATER,
+              PERSPECTIVE_INSTANCE_PINNED
+            )}
+        >
+          Pin the width (fix)
+        </button>
+        <button
+          type="button"
+          style=${buttonStyle}
+          @click=${(e: Event) =>
+            applyLayout(
+              e.currentTarget,
+              PERSPECTIVE_REPEATER,
+              PERSPECTIVE_INSTANCE
+            )}
+        >
+          Free the width (reproduce)
+        </button>
+      `
+    ),
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend/gauge-trend.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend/gauge-trend.stories.ts
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/web-components-vite';
 import {html} from 'lit';
+import {ref} from 'lit/directives/ref.js';
 import './gauge-trend.js';
 import {AdviceType} from '../watch/advice.js';
 import {
@@ -1130,4 +1131,219 @@ export const RealtimeShifting: Story = {
 
     return wrapper;
   },
+};
+
+// Host boxes straddling the 2:1 ratio. Every box is a definite pixel size and
+// the gauge is told the same width/height, so nothing here is ambiguous.
+const CLAMP_CASES = [
+  {width: 600, height: 400},
+  {width: 800, height: 400},
+  {width: 1000, height: 400},
+  {width: 1600, height: 400},
+  {width: 1600, height: 640},
+];
+
+const clampProbes = new Set<number>();
+
+/** Live box-vs-canvas readout, so the clamp is a number rather than an impression. */
+const measureClamp = (root?: Element) => {
+  if (!(root instanceof HTMLElement)) {
+    clampProbes.forEach((id) => clearInterval(id));
+    clampProbes.clear();
+    return;
+  }
+  const paint = () => {
+    root.querySelectorAll('[data-clamp-box]').forEach((node) => {
+      const box = node as HTMLElement;
+      const canvas = box
+        .querySelector('obc-gauge-trend')
+        ?.shadowRoot?.querySelector('canvas');
+      const out = box.previousElementSibling as HTMLElement | null;
+      if (!canvas || !out) return;
+      const b = box.getBoundingClientRect();
+      const c = canvas.getBoundingClientRect();
+      const unused = Math.round(b.width - c.width);
+      out.textContent =
+        `box ${Math.round(b.width)}×${Math.round(b.height)} ` +
+        `(${(b.width / b.height).toFixed(2)}:1)` +
+        `   canvas ${Math.round(c.width)}×${Math.round(c.height)} ` +
+        `(${(c.width / c.height).toFixed(2)}:1)` +
+        `   unused width ${unused}px` +
+        (unused > 1 ? '   ← clamped' : '   ✓ fills');
+    });
+  };
+  paint();
+  clampProbes.add(window.setInterval(paint, 500));
+};
+
+/**
+ * **Bug — the chart canvas never grows past 2 × its own height.**
+ *
+ * Each dashed box below has a definite pixel size and the gauge is given the
+ * matching `width` / `height`. Up to a 2:1 box the canvas fills it exactly.
+ * Past 2:1 the canvas stops at `height × 2` and is centred by
+ * `chart-common.css .wrapper { justify-content: center; align-items: center }`,
+ * so the remainder shows up as symmetric empty margins. At 4:1 two thirds of
+ * the box is blank.
+ *
+ * The numbers above each box are measured live from the DOM.
+ *
+ * Why 2:1: `.wrapper` centres on the cross axis, so
+ * `.canvas-and-slots-container` is shrink-to-fit and `canvas { width: 100% }`
+ * has no definite basis to resolve against. Chart.js then falls back to its
+ * default `aspectRatio: 2` — `chart.aspectRatio === 2` on the clamped charts
+ * even though `chart-line-base` sets `maintainAspectRatio: false` and never
+ * sets `aspectRatio`. Below 2:1 the height constraint binds first, which is
+ * why the default portrait instruments never show it.
+ *
+ * Surfaced through `obc-automation-tank` in `graph` / `graph-and-bar` mode on a
+ * wide dashboard tile — the tank's chart cell inherits the gap. `bar` mode has
+ * no canvas and is unaffected.
+ */
+export const BugCanvasClampedToTwoToOne: Story = {
+  name: 'BUG: Canvas Never Exceeds 2 × Its Height',
+  args: {browserContainerWidth: 1700},
+  parameters: {controls: {disable: true}},
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 16px; padding: 8px; overflow: auto;"
+      ${ref(measureClamp)}
+    >
+      ${CLAMP_CASES.map(
+        (size) => html`
+          <div>
+            <code
+              style="display: block; margin-bottom: 4px; font: 12px/1.6 monospace; color: var(--element-neutral-color);"
+              >measuring…</code
+            >
+            <div
+              data-clamp-box
+              style="
+                width: ${size.width}px;
+                height: ${size.height}px;
+                box-sizing: border-box;
+                outline: 1px dashed var(--border-divider-color);
+              "
+            >
+              <obc-gauge-trend
+                style="width: 100%; height: 100%;"
+                .data=${SAMPLE_DATA}
+                .width=${size.width}
+                .height=${size.height}
+                .minValue=${0}
+                .maxValue=${100}
+                .value=${40}
+                .hasBar=${true}
+                .hasScale=${false}
+                .hasLabelPadding=${false}
+                .chartFill=${true}
+              ></obc-gauge-trend>
+            </div>
+          </div>
+        `
+      )}
+    </div>
+  `,
+};
+
+// Portrait host, well under the 2:1 clamp, so zoom is the only variable.
+const ZOOM_CASES = [1, 0.8, 0.5, 1.25];
+
+const zoomProbes = new Set<number>();
+
+const measureZoom = (root?: Element) => {
+  if (!(root instanceof HTMLElement)) {
+    zoomProbes.forEach((id) => clearInterval(id));
+    zoomProbes.clear();
+    return;
+  }
+  const paint = () => {
+    root.querySelectorAll('[data-zoom-box]').forEach((node) => {
+      const box = node as HTMLElement;
+      const canvas = box
+        .querySelector('obc-gauge-trend')
+        ?.shadowRoot?.querySelector('canvas');
+      const out = box.previousElementSibling as HTMLElement | null;
+      if (!canvas || !out) return;
+      // Both rects are in the same (zoomed) space, so the ratio is honest.
+      const b = box.getBoundingClientRect();
+      const c = canvas.getBoundingClientRect();
+      const zoom = Number(box.dataset.zoomBox);
+      out.textContent =
+        `zoom ${zoom}` +
+        `   box ${Math.round(b.width)}×${Math.round(b.height)}` +
+        `   canvas ${Math.round(c.width)}×${Math.round(c.height)}` +
+        `   canvas/box ${(c.width / b.width).toFixed(2)}` +
+        `   (zoom² = ${(zoom * zoom).toFixed(2)})` +
+        (Math.abs(c.width / b.width - 1) < 0.01 ? '   ✓' : '   ←');
+    });
+  };
+  paint();
+  zoomProbes.add(window.setInterval(paint, 500));
+};
+
+/**
+ * **Bug — CSS `zoom` is applied twice to the chart canvas.**
+ *
+ * Each dashed box is 200×165 with a different `zoom`. The canvas comes out at
+ * `zoom²` of its box: 64% at `zoom: 0.8`, 25% at `zoom: 0.5`, and it overflows
+ * at `zoom: 1.25`. The host is portrait, far from the 2:1 clamp, so zoom is
+ * the only variable.
+ *
+ * Chart.js measures the container with `getBoundingClientRect()`, which is
+ * already zoom-scaled, then writes that number back as a CSS-pixel inline
+ * `style` on the canvas — which the browser then scales again. At `zoom: 0.8`
+ * the inline style reads `width: 128px` for a box whose CSS width is 200px.
+ *
+ * `zoom` is not exotic: a whole-application `html { zoom: … }` is a common way
+ * to fit a fixed layout to a display, and it silently shrinks every gauge on
+ * the page.
+ *
+ * The numbers above each box are measured live from the DOM.
+ */
+export const BugCssZoomAppliedTwice: Story = {
+  name: 'BUG: CSS Zoom Shrinks The Chart Canvas',
+  args: {browserContainerWidth: 900},
+  parameters: {controls: {disable: true}},
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 16px; padding: 8px;"
+      ${ref(measureZoom)}
+    >
+      ${ZOOM_CASES.map(
+        (zoom) => html`
+          <div>
+            <code
+              style="display: block; margin-bottom: 4px; font: 12px/1.6 monospace; color: var(--element-neutral-color);"
+              >measuring…</code
+            >
+            <div
+              data-zoom-box=${zoom}
+              style="
+                zoom: ${zoom};
+                width: 200px;
+                height: 165px;
+                box-sizing: border-box;
+                outline: 1px dashed var(--border-divider-color);
+              "
+            >
+              <obc-gauge-trend
+                style="width: 100%; height: 100%;"
+                .data=${SAMPLE_DATA}
+                .width=${200}
+                .height=${165}
+                .minValue=${0}
+                .maxValue=${100}
+                .value=${40}
+                .hasBar=${true}
+                .hasScale=${false}
+                .hasLabelPadding=${false}
+                .chartFill=${true}
+              ></obc-gauge-trend>
+            </div>
+          </div>
+        `
+      )}
+    </div>
+  `,
 };


### PR DESCRIPTION
A reproduction of a UI issue with automation tank.

This is just to show the reproduction in storybook. 

### Do **not** merge.

## Reproductions
https://openbridge-next-storybook--1137-bug-runaway-resizing-t-lunbtk1u.web.app/?path=/story/instruments-gauge-trend--bug-css-zoom-applied-twice
https://openbridge-next-storybook--1137-bug-runaway-resizing-t-lunbtk1u.web.app/?path=/story/automation-tanks-tank--bug-chart-canvas-does-not-fill-cell

## Issue
https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/issues/1138