### PR TITLE
fix(stepper-box): commit value on change and forward value update rejection

### DIFF
--- a/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.spec.ts
+++ b/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.spec.ts
@@ -1,0 +1,159 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import './stepper-box.js';
+import {ObcStepperBox} from './stepper-box.js';
+import {ObcNumberInputField} from '../number-input-field/number-input-field.js';
+import {render} from 'vitest-browser-lit';
+import {html} from 'lit';
+
+describe('obc-stepper-box', () => {
+  let el: ObcStepperBox;
+  let field: ObcNumberInputField;
+  let input: HTMLInputElement;
+
+  beforeEach(async () => {
+    const screen = render(
+      html`<obc-stepper-box
+        .value=${10}
+        .min=${0}
+        .max=${100}
+      ></obc-stepper-box>`
+    );
+    el = screen.baseElement.querySelector('obc-stepper-box') as ObcStepperBox;
+    await el.updateComplete;
+    field = el.shadowRoot!.querySelector(
+      'obc-number-input-field'
+    ) as ObcNumberInputField;
+    await field.updateComplete;
+    input = field.shadowRoot!.querySelector('.value-input') as HTMLInputElement;
+  });
+
+  const type = async (text: string) => {
+    input.focus();
+    input.value = text;
+    input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    await field.updateComplete;
+    await el.updateComplete;
+  };
+
+  const blur = async () => {
+    input.blur();
+    await field.updateComplete;
+    await el.updateComplete;
+  };
+
+  describe('input event', () => {
+    it('dispatches input with the raw text on every keystroke', async () => {
+      const handler = vi.fn();
+      el.addEventListener('input', handler);
+
+      await type('12');
+      await type('12.');
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler.mock.calls[0][0].detail).toEqual({value: '12'});
+      expect(handler.mock.calls[1][0].detail).toEqual({value: '12.'});
+      expect(el.value).toBe(12);
+    });
+
+    it('does not dispatch change while editing', async () => {
+      const handler = vi.fn();
+      el.addEventListener('change', handler);
+
+      await type('12');
+      await type('12.5');
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('change event', () => {
+    it('dispatches change once when the edit is committed', async () => {
+      const handler = vi.fn();
+      el.addEventListener('change', handler);
+
+      await type('12.5');
+      await blur();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].detail).toEqual({value: 12.5});
+      expect(el.value).toBe(12.5);
+    });
+
+    it('does not dispatch change when the committed value is unchanged', async () => {
+      const handler = vi.fn();
+      el.addEventListener('change', handler);
+
+      await type('10');
+      await blur();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('commits null when the field is cleared', async () => {
+      const handler = vi.fn();
+      el.addEventListener('change', handler);
+
+      await type('');
+      await blur();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].detail).toEqual({value: null});
+      expect(el.value).toBeNull();
+    });
+  });
+
+  describe('step buttons', () => {
+    it('dispatches up and change', async () => {
+      const up = vi.fn();
+      const change = vi.fn();
+      el.addEventListener('up', up);
+      el.addEventListener('change', change);
+
+      el.up();
+      await el.updateComplete;
+
+      expect(el.value).toBe(11);
+      expect(up.mock.calls[0][0].detail).toEqual({value: 11});
+      expect(change.mock.calls[0][0].detail).toEqual({value: 11});
+    });
+
+    it('dispatches down and change', async () => {
+      const down = vi.fn();
+      const change = vi.fn();
+      el.addEventListener('down', down);
+      el.addEventListener('change', change);
+
+      el.down();
+      await el.updateComplete;
+
+      expect(el.value).toBe(9);
+      expect(down.mock.calls[0][0].detail).toEqual({value: 9});
+      expect(change.mock.calls[0][0].detail).toEqual({value: 9});
+    });
+  });
+
+  describe('value update rejection', () => {
+    it('forwards the rejection properties to the number input field', async () => {
+      el.rejectUpdatesOnFocus = true;
+      el.rejectUpdates = true;
+      el.rejectDuplicateUpdates = true;
+      await el.updateComplete;
+
+      expect(field.rejectUpdatesOnFocus).toBe(true);
+      expect(field.rejectUpdates).toBe(true);
+      expect(field.rejectDuplicateUpdates).toBe(true);
+    });
+
+    it('keeps the typed text when an external value update arrives while focused', async () => {
+      el.rejectUpdatesOnFocus = true;
+      await el.updateComplete;
+
+      await type('42');
+      el.value = 10;
+      await el.updateComplete;
+      await field.updateComplete;
+
+      expect(input.value).toBe('42');
+    });
+  });
+});

--- a/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.ts
+++ b/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.ts
@@ -10,7 +10,10 @@ import '../../icons/icon-chevron-right-google.js';
 import '../../icons/icon-chevron-left-google.js';
 import {customElement} from '../../decorator.js';
 import '../number-input-field/number-input-field.js';
-import {ObcNumberInputFieldTextAlign} from '../number-input-field/number-input-field.js';
+import {
+  ObcNumberInputField,
+  ObcNumberInputFieldTextAlign,
+} from '../number-input-field/number-input-field.js';
 
 /**
  * The visual and behavioral variant of the stepper box.
@@ -48,6 +51,8 @@ export enum ObcStepperBoxType {
  * ### Events
  * - `down` – Fired when the decrement (left or down) button is clicked.
  * - `up` – Fired when the increment (right or up) button is clicked.
+ * - `input` – Fired while the user edits the number input field.
+ * - `change` – Fired when the edit is committed, or when a step button is used.
  *
  * ### Best Practices
  * - Use the type that best matches the adjustment direction (e.g., `up-down` for vertical, `left-right` for horizontal, `plus-minus` for generic increment/decrement).
@@ -73,7 +78,7 @@ export enum ObcStepperBoxType {
  * @fires {CustomEvent<{value: number}>} down - Fired when the decrement (left or down) button is clicked
  * @fires {CustomEvent<{value: number}>} up - Fired when the increment (right or up) button is clicked
  * @fires {CustomEvent<{value: string}>} input - Fired when the user types in the number input field
- * @fires {CustomEvent<{value: number | null}>} change - Fired when the value changes through the input field or the increment/decrement buttons; programmatic assignment to `value` does not dispatch it
+ * @fires {CustomEvent<{value: number | null}>} change - Fired when the edit is committed on blur, or when the increment/decrement buttons are used; programmatic assignment to `value` does not dispatch it
  * @stable
  */
 @customElement('obc-stepper-box')
@@ -108,6 +113,17 @@ export class ObcStepperBox extends LitElement {
   @property({type: String}) placeholder = '';
 
   @property({type: Boolean}) readonly = false;
+
+  /** If true, the input field will not update its value on focus */
+  @property({type: Boolean}) rejectUpdatesOnFocus = false;
+
+  /** If true, the value will only be initially set, and not updated on change */
+  @property({type: Boolean}) rejectUpdates = false;
+
+  /** If true, the input field will not update its value if the value is the same as the previous value
+   * This is useful to avoid React re-rendering to reset the value.
+   */
+  @property({type: Boolean}) rejectDuplicateUpdates = false;
 
   private get downDisabled(): boolean {
     return (
@@ -203,7 +219,11 @@ export class ObcStepperBox extends LitElement {
               .textAlign=${ObcNumberInputFieldTextAlign.Center}
               ?disabled=${this.disabled}
               ?readonly=${this.readonly}
+              .rejectUpdatesOnFocus=${this.rejectUpdatesOnFocus}
+              .rejectUpdates=${this.rejectUpdates}
+              .rejectDuplicateUpdates=${this.rejectDuplicateUpdates}
               @input=${this.onNumberFieldInput}
+              @change=${this.onNumberFieldChange}
             ></obc-number-input-field>
           </div>
           <obc-icon-button
@@ -223,30 +243,27 @@ export class ObcStepperBox extends LitElement {
   }
 
   private onNumberFieldInput(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const raw = input.value;
+    const field = e.target as ObcNumberInputField;
+
     this.dispatchEvent(
       new CustomEvent('input', {
-        detail: {value: raw},
+        detail: {value: field.displayValue},
         bubbles: true,
         composed: true,
       })
     );
 
-    if (raw.trim() === '') {
-      return;
+    if (Number.isFinite(field.value)) {
+      this.value = field.value;
     }
+  }
 
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed)) {
-      return;
-    }
+  private onNumberFieldChange(e: Event) {
+    const value = (e as CustomEvent<{value: number}>).detail.value;
+    const committed = Number.isFinite(value) ? value : null;
 
-    const previous = this.value;
-    this.value = parsed;
-    if (previous !== this.value) {
-      this.dispatchChange(this.value);
-    }
+    this.value = committed;
+    this.dispatchChange(committed);
   }
 
   private dispatchChange(value: number | null) {

--- a/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.ts
+++ b/packages/openbridge-webcomponents/src/components/stepper-box/stepper-box.ts
@@ -75,6 +75,9 @@ export enum ObcStepperBoxType {
  * @property helperText - Helper text displayed below the stepper. When set, the helper text is shown.
  * @property placeholder - Placeholder text shown when the input is empty.
  * @property readonly - If true, the input is non-editable; programmatic value changes still apply.
+ * @property rejectUpdatesOnFocus - If true, the input field will not update its value on focus
+ * @property rejectUpdates - If true, the value will only be initially set, and not updated on change
+ * @property rejectDuplicateUpdates - If true, the input field will not update its value if the value is the same as the previous value
  * @fires {CustomEvent<{value: number}>} down - Fired when the decrement (left or down) button is clicked
  * @fires {CustomEvent<{value: number}>} up - Fired when the increment (right or up) button is clicked
  * @fires {CustomEvent<{value: string}>} input - Fired when the user types in the number input field
@@ -114,15 +117,10 @@ export class ObcStepperBox extends LitElement {
 
   @property({type: Boolean}) readonly = false;
 
-  /** If true, the input field will not update its value on focus */
   @property({type: Boolean}) rejectUpdatesOnFocus = false;
 
-  /** If true, the value will only be initially set, and not updated on change */
   @property({type: Boolean}) rejectUpdates = false;
 
-  /** If true, the input field will not update its value if the value is the same as the previous value
-   * This is useful to avoid React re-rendering to reset the value.
-   */
   @property({type: Boolean}) rejectDuplicateUpdates = false;
 
   private get downDisabled(): boolean {


### PR DESCRIPTION
Attempts to align the stepper box closer to the other input fields in terms of the API around input and change events.

This might not be right approach, but can maybe serve as a starting point for aligning them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for rejected, duplicate, and focused updates in the stepper box.
  - Improved numeric input and change events, including support for cleared values.
  - Preserved typed text when external updates are rejected.
  - Added clearer support for committing edited values and using step-up and step-down controls.

- **Bug Fixes**
  - Ensured stepper values update only when valid finite numbers are entered.
  - Improved consistency when entering, clearing, or externally updating values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->