### PR TITLE
feat(alert-list-details): add showTagId to toggle the Tag ID column

### DIFF
--- a/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.stories.ts
@@ -42,6 +42,7 @@ const meta: Meta<typeof ObcAlertListDetails> = {
   args: {
     selectedMode: AlertListMode.ALL,
     showTime: true,
+    showTagId: true,
     alerts: [
       {
         id: '1',
@@ -132,6 +133,7 @@ const meta: Meta<typeof ObcAlertListDetails> = {
       data-testid="alert-menu"
       .selectedMode=${args.selectedMode}
       .showTime=${args.showTime}
+      .showTagId=${args.showTagId}
       .small=${args.small}
       @ack-click=${handleAck}
       .alerts=${args.alerts}
@@ -151,6 +153,12 @@ export const Regular: Story = {
 export const Small: Story = {
   args: {
     small: true,
+  },
+};
+
+export const WithoutTagId: Story = {
+  args: {
+    showTagId: false,
   },
 };
 

--- a/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.ts
+++ b/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.ts
@@ -112,7 +112,8 @@ export function canAckFilter(filter: (alert: Alert) => boolean) {
 
 /**
  * @availableWhen timeFormatter showTime==true
- * @property showTagId - Whether to render the Tag ID column. The small variant never renders it.
+ * @property showTagId - Whether to render the Tag ID column.
+ * @availableWhen showTagId small==false
  * @fires {ObcAckClickEvent} ack-click - Fired when the user clicks the "ACK" button.
  * @fires {ObcRowClickEvent} row-click - Fired when the user clicks a row.
  * @stable

--- a/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.ts
+++ b/packages/openbridge-webcomponents/src/components/alert-list-details/alert-list-details.ts
@@ -112,6 +112,7 @@ export function canAckFilter(filter: (alert: Alert) => boolean) {
 
 /**
  * @availableWhen timeFormatter showTime==true
+ * @property showTagId - Whether to render the Tag ID column. The small variant never renders it.
  * @fires {ObcAckClickEvent} ack-click - Fired when the user clicks the "ACK" button.
  * @fires {ObcRowClickEvent} row-click - Fired when the user clicks a row.
  * @stable
@@ -121,6 +122,7 @@ export class ObcAlertListDetails extends LitElement {
   @property({type: String}) selectedMode: AlertListMode = AlertListMode.ALL;
   @property({type: Array}) alerts: Alert[] = [];
   @property({type: Boolean}) showTime: boolean = false;
+  @property({type: Boolean, attribute: false}) showTagId: boolean = true;
   @property({attribute: false}) timeFormatter: (time: Date) => string = (
     time: Date
   ) => time.toLocaleTimeString(undefined, {hour12: false});
@@ -226,18 +228,20 @@ export class ObcAlertListDetails extends LitElement {
           },
         });
       }
-      columns.push({
-        label: 'Tag ID',
-        key: 'tagId',
-        sortable: true,
-        compareFunction: (a, b) => {
-          const aText =
-            a?.type === ObcTableCellType.Regular ? String(a.text ?? '') : '';
-          const bText =
-            b?.type === ObcTableCellType.Regular ? String(b.text ?? '') : '';
-          return aText.localeCompare(bText);
-        },
-      });
+      if (this.showTagId) {
+        columns.push({
+          label: 'Tag ID',
+          key: 'tagId',
+          sortable: true,
+          compareFunction: (a, b) => {
+            const aText =
+              a?.type === ObcTableCellType.Regular ? String(a.text ?? '') : '';
+            const bText =
+              b?.type === ObcTableCellType.Regular ? String(b.text ?? '') : '';
+            return aText.localeCompare(bText);
+          },
+        });
+      }
       return columns;
     }
   }
@@ -302,13 +306,14 @@ export class ObcAlertListDetails extends LitElement {
           }
         : undefined;
 
-      const tagId = this.small
-        ? undefined
-        : {
-            type: ObcTableCellType.Regular,
-            text: '#' + alert.id,
-            align: 'right',
-          };
+      const tagId =
+        this.small || !this.showTagId
+          ? undefined
+          : {
+              type: ObcTableCellType.Regular,
+              text: '#' + alert.id,
+              align: 'right',
+            };
       return {
         id: alert.id,
         status,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to show or hide the Tag ID column and its values in alert list details.
  - Tag IDs are shown by default for applicable, non-small alert lists, while small lists continue to omit them.
  - Added an example demonstrating alert list details without Tag IDs, helping showcase the configurable display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->