### PR TITLE
docs(readout): promote the readout family to beta

### DIFF
--- a/.claude/rules/readout-components.md
+++ b/.claude/rules/readout-components.md
@@ -277,7 +277,9 @@ Do not treat these as settled when editing:
 - `obc-readout` and `obc-readout-list-item` are layout variants of one API and
   **may merge**. Keep shared behaviour in `readout-shared.ts` so the merge stays
   cheap — do not re-inline it per component.
-- The whole family is `@experimental`.
+- Lifecycle: `obc-textbox`, `obc-readout-block`, `obc-readout` and
+  `obc-readout-list-item` are `@beta`; `obc-readout-list` stays
+  `@experimental` because the API for grouping rows may still change.
 - The large-tier label-`s` default and the regular-weight label are
   **confirmed** by the design team (2026-08-17); only the medium-tier label
   default remains unverified (`labelSize` carries the TODO).

--- a/.cursor/rules/readout-components.mdc
+++ b/.cursor/rules/readout-components.mdc
@@ -271,7 +271,9 @@ Do not treat these as settled when editing:
 - `obc-readout` and `obc-readout-list-item` are layout variants of one API and
   **may merge**. Keep shared behaviour in `readout-shared.ts` so the merge stays
   cheap — do not re-inline it per component.
-- The whole family is `@experimental`.
+- Lifecycle: `obc-textbox`, `obc-readout-block`, `obc-readout` and
+  `obc-readout-list-item` are `@beta`; `obc-readout-list` stays
+  `@experimental` because the API for grouping rows may still change.
 - The large-tier label-`s` default and the regular-weight label are
   **confirmed** by the design team (2026-08-17); only the medium-tier label
   default remains unverified (`labelSize` carries the TODO).

--- a/.github/instructions/readout-components.instructions.md
+++ b/.github/instructions/readout-components.instructions.md
@@ -270,7 +270,9 @@ Do not treat these as settled when editing:
 - `obc-readout` and `obc-readout-list-item` are layout variants of one API and
   **may merge**. Keep shared behaviour in `readout-shared.ts` so the merge stays
   cheap — do not re-inline it per component.
-- The whole family is `@experimental`.
+- Lifecycle: `obc-textbox`, `obc-readout-block`, `obc-readout` and
+  `obc-readout-list-item` are `@beta`; `obc-readout-list` stays
+  `@experimental` because the API for grouping rows may still change.
 - The large-tier label-`s` default and the regular-weight label are
   **confirmed** by the design team (2026-08-17); only the medium-tier label
   default remains unverified (`labelSize` carries the TODO).

--- a/docs/agents/readout-components.md
+++ b/docs/agents/readout-components.md
@@ -275,7 +275,9 @@ Do not treat these as settled when editing:
 - `obc-readout` and `obc-readout-list-item` are layout variants of one API and
   **may merge**. Keep shared behaviour in `readout-shared.ts` so the merge stays
   cheap — do not re-inline it per component.
-- The whole family is `@experimental`.
+- Lifecycle: `obc-textbox`, `obc-readout-block`, `obc-readout` and
+  `obc-readout-list-item` are `@beta`; `obc-readout-list` stays
+  `@experimental` because the API for grouping rows may still change.
 - The large-tier label-`s` default and the regular-weight label are
   **confirmed** by the design team (2026-08-17); only the medium-tier label
   default remains unverified (`labelSize` carries the TODO).

--- a/packages/openbridge-webcomponents/src/building-blocks/readout-block/readout-block.stories.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/readout-block/readout-block.stories.ts
@@ -120,7 +120,7 @@ function renderShowcase(cards: ShowcaseCard[]) {
 
 const meta = {
   title: 'Building Blocks/Readout Block',
-  tags: ['autodocs', '6.0', 'experimental'],
+  tags: ['autodocs', '6.0', 'beta'],
   component: 'obc-readout-block',
   decorators: [themedDecorator],
   parameters: {

--- a/packages/openbridge-webcomponents/src/building-blocks/readout-block/readout-block.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/readout-block/readout-block.ts
@@ -187,7 +187,7 @@ export enum ReadoutBlockHidePhase {
  * @csspart block-text - The `obc-textbox` rendering the number.
  * @csspart block-icon - The leading marker-icon container.
  * @csspart degree - The trailing degree-glyph column.
- * @experimental
+ * @beta
  */
 @customElement('obc-readout-block')
 export class ObcReadoutBlock extends LitElement {

--- a/packages/openbridge-webcomponents/src/components/textbox/textbox.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/textbox/textbox.stories.ts
@@ -15,7 +15,7 @@ interface TextboxStoryArgs extends Partial<ObcTextbox> {
 
 const meta: Meta<TextboxStoryArgs> = {
   title: 'Building Blocks/Textbox',
-  tags: ['autodocs', '6.0', 'experimental'],
+  tags: ['autodocs', '6.0', 'beta'],
   component: 'obc-textbox',
   args: {
     size: ObcTextboxSize.m,

--- a/packages/openbridge-webcomponents/src/components/textbox/textbox.ts
+++ b/packages/openbridge-webcomponents/src/components/textbox/textbox.ts
@@ -66,7 +66,7 @@ export enum ObcTextboxFontWeight {
  *
  * @slot - The visible text content.
  * @slot length - Reserves a minimum width based on its content width.
- * @experimental
+ * @beta
  */
 @customElement('obc-textbox')
 export class ObcTextbox extends LitElement {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/readout-list-item/readout-list-item.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/readout-list-item/readout-list-item.stories.ts
@@ -343,7 +343,7 @@ function argsToOptions(args: ReadoutListItemStoryArgs): StoryOptions {
 
 const meta = {
   title: 'Instruments/Readout List Item',
-  tags: ['autodocs', '6.0', 'experimental'],
+  tags: ['autodocs', '6.0', 'beta'],
   component: 'obc-readout-list-item',
   decorators: [centeredCanvasDecorator],
   render: (args) =>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/readout-list-item/readout-list-item.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/readout-list-item/readout-list-item.ts
@@ -345,7 +345,7 @@ export interface ReadoutSrcOptions extends ReadoutBlockState {
  * @slot setpoint-icon - Overrides the default setpoint icon.
  * @slot advice-icon - Overrides the default advice icon.
  * @fires click - Fired when the item is activated. Only fired when `clickable` is set; otherwise the item renders as a non-interactive `<div>`.
- * @experimental
+ * @beta
  */
 @customElement('obc-readout-list-item')
 export class ObcReadoutListItem extends LitElement {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.stories.ts
@@ -364,7 +364,7 @@ function argsToOptions(args: ReadoutStoryArgs): StoryOptions {
 
 const meta = {
   title: 'Instruments/Readout',
-  tags: ['autodocs', '6.0', 'experimental'],
+  tags: ['autodocs', '6.0', 'beta'],
   component: 'obc-readout',
   decorators: [centeredCanvasDecorator],
   render: (args) =>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.ts
@@ -304,7 +304,7 @@ export interface ReadoutSourceOptions extends ReadoutSrcOptions {
  * @slot src-picker-content - Provides the source picker context menu content.
  * @fires {CustomEvent<{value: string, label?: string}>} source-change - Fired when a source picker option is selected.
  * @fires {CustomEvent<{src: string}>} source-flyout-click - Fired when the source row is clicked while `srcOptions.interaction == 'flyout'`.
- * @experimental
+ * @beta
  */
 @customElement('obc-readout')
 export class ObcReadout extends LitElement {


### PR DESCRIPTION
## Summary

Moves four of the five readout-stack components from **Experimental** to **Beta**
in Storybook: `obc-textbox`, `obc-readout-block`, `obc-readout` and
`obc-readout-list-item`. `obc-readout-list` deliberately stays `@experimental`.

No runtime behaviour changes — this is a lifecycle/metadata change only, so the
`docs:` type is correct and nothing ships.

- [Readout List Item](https://openbridge-next-storybook.web.app/?path=/docs/instruments-readout-list-item--docs)
- [Readout](https://openbridge-next-storybook.web.app/?path=/docs/instruments-readout--docs)
- [Readout Block](https://openbridge-next-storybook.web.app/?path=/docs/building-blocks-readout-block--docs)
- [Textbox](https://openbridge-next-storybook.web.app/?path=/docs/building-blocks-textbox--docs)

## Why

The stack has been through the Figma 6.1 alignment (#1145), the final family
check (#1205) and the helper consolidation (#1209 / #1210). The API is
feature-complete for these four, which is exactly what `@beta` means in
[`docs/agents/jsdoc.md`](https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/blob/develop/docs/agents/jsdoc.md) — "feature-complete,
API may still change". `@experimental` ("early stage, API likely to change") now
understates their maturity, and the Experimental badge discourages adoption of
components we would like consumers to build on.

`obc-readout-list` is held back on request: it is the one component whose public
surface is still expected to move, because the API for **grouping** multiple list
items is not settled.

## What changed

| Component | Was | Now |
| --------- | --- | --- |
| `obc-textbox` | `@experimental` | `@beta` |
| `obc-readout-block` | `@experimental` | `@beta` |
| `obc-readout` | `@experimental` | `@beta` |
| `obc-readout-list-item` | `@experimental` | `@beta` |
| `obc-readout-list` | `@experimental` | **unchanged** |

- **Class JSDoc** — the single source of truth. One tag swapped per component.
- **`meta.tags` in the four story files** — rewritten by
  `npm run lint:fix:stories`, never by hand, per
  [`docs/agents/jsdoc.md` § Component lifecycle tags](https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/blob/develop/docs/agents/jsdoc.md).
  The Storybook sidebar/docs badge is driven from these tags by
  `.storybook/manager.ts`.
- **`docs/agents/readout-components.md`** — the "Open / in flux" section claimed
  "The whole family is `@experimental`", which is no longer true. It now records
  the split and *why* the list is held back. The three generated mirrors
  (`.claude/rules/`, `.cursor/rules/`, `.github/instructions/`) were regenerated
  with `npm run agents:sync`.

## Alternatives considered (and why not)

- **Promote `obc-readout-list` too** — rejected on request: grouping more list
  items is an open API question, and a Beta badge would signal a stability the
  component does not have yet.
- **Go straight to `@stable`** — premature. Several items in the family's
  "Open / in flux" list are still live (hinted zeros on negative values, the
  medium-tier `labelSize` default, advice category icons/colours, the Figma
  source `Tag` type), and `obc-readout` / `obc-readout-list-item` may still merge.
  `@beta` says "feature-complete, API may still change", which is exactly right.
- **Hand-edit `meta.tags`** — explicitly forbidden by the repo docs; the ESLint
  rule `openbridge/story-lifecycle-tags` would have failed the build.

## Verification

Run from `packages/openbridge-webcomponents`:

| Command | Result |
| ------- | ------ |
| `npm run lint:eslint` | **0 errors.** `openbridge/story-lifecycle-tags` confirms every story's `meta.tags` agrees with its class JSDoc; no warnings on any touched file. The 17 remaining warnings are pre-existing and in unrelated files. |
| `npm run lint:agents` | `agent-docs: up to date` — mirrors match `docs/agents/`. |
| `npm run lint:slots` | Passed, 282 components scanned. |
| `npm run lint:comments` | 0 errors, none on touched files. |
| pre-commit `lint-staged` | eslint + prettier passed on the 8 staged source files. |

No visual baselines move — the sidebar badge is Storybook manager chrome, not
canvas content, and no story renders differently.

## Docs

- [x] docs/agents updated — `readout-components.md` "Open / in flux" now records
      the per-component lifecycle instead of the stale "whole family" claim, and
      the generated mirrors were re-synced.
- [x] Comment pass done (`npm run lint:comments` clean for touched files)

## Follow-ups

- `obc-readout-list` promotion is blocked on the grouping API. Worth a tracking
  issue once the grouping design lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated lifecycle classifications for readout components.
  - Marked Textbox, Readout Block, Readout, and Readout List Item as **Beta**.
  - Retained Readout List’s **Experimental** status.
- **Storybook**
  - Updated component status labels to reflect the revised lifecycle classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->